### PR TITLE
Adds ability to rotate labels on the axis

### DIFF
--- a/public/heatmap.js
+++ b/public/heatmap.js
@@ -15,8 +15,8 @@ function HeatmapProvider(Private) {
     template: require('plugins/heatmap/heatmap.html'),
     params: {
       defaults: {
-        margin: { top: 20, right: 200, bottom: 50, left: 100 },
-        stroke: 'white',
+        margin: { top: 20, right: 200, bottom: 100, left: 100 },
+        stroke: '#eee',
         strokeWidth: 1,
         padding: 0
       },

--- a/public/lib/heatmap_controller.js
+++ b/public/lib/heatmap_controller.js
@@ -71,8 +71,8 @@ module.controller('HeatmapController', function ($scope) {
       }];
 
     _.merge($scope.vis.params, {
-      rowAxisTitle: getLabel($scope.vis.aggs, 'rows'),
-      columnAxisTitle: getLabel($scope.vis.aggs, 'columns')
+      rowAxis: { title: getLabel($scope.vis.aggs, 'rows') },
+      columnAxis: { title: getLabel($scope.vis.aggs, 'columns') }
     });
 
     $scope.data = [{ cells: cells }];

--- a/public/vis/components/axis/axis.js
+++ b/public/vis/components/axis/axis.js
@@ -6,6 +6,7 @@ function axes() {
   var scale = d3.scale.linear();
   var orientation = 'left';
   var rotateLabels = false;
+  var rotateOptions = {};
   var ticks = {};
   var title = {};
   var transform = 'translate(0,0)';
@@ -37,9 +38,21 @@ function axes() {
         .call(axis);
 
       if (rotateLabels) {
-        var axisLength = Math.abs(scale.range()[1] - scale.range()[0]);
+        var axisLength;
 
-        rotation.axisLength(axisLength);
+        if (_.isFunction(scale.rangeBand)) {
+          axisLength = Math.abs(_.last(scale.range()) + scale.rangeBand());
+        } else {
+          axisLength = Math.abs(scale.range()[1] - scale.range()[0]);
+        }
+
+        rotation
+          .axisLength(axisLength)
+          .measure(rotateOptions.measure || 'width')
+          .text({
+            transform: rotateOptions.transform || 'translate(0,0)rotate(-45)'
+          });
+
         g.call(rotation);
       }
 
@@ -101,6 +114,13 @@ function axes() {
   generator.rotateLabels = function (v) {
     if (!arguments.length) return rotateLabels;
     rotateLabels = v;
+    return generator;
+  };
+
+  generator.rotateOptions = function (v) {
+    if (!arguments.length) return rotateOptions;
+    rotateOptions.measure = typeof v.measure !== 'undefined' ? v.measure : rotateOptions.measure;
+    rotateOptions.transform = typeof v.transform !== 'undefined' ? v.transform : rotateOptions.transform;
     return generator;
   };
 

--- a/public/vis/components/axis/rotate.js
+++ b/public/vis/components/axis/rotate.js
@@ -13,7 +13,7 @@ function rotate() {
       var ticks = d3.select(this).selectAll('.tick text');
       var numOfTicks = ticks[0].length;
       var maxTickLabelLength = (axisLength / numOfTicks) - labelPadding;
-      var isRotated;
+      var isRotated = false;
 
       ticks.each(function () {
         var labelLength = this.getBBox()[measure];
@@ -36,6 +36,9 @@ function rotate() {
         ticks.each(function () {
           d3.select(this).call(truncate().maxCharLength(truncateLength));
         });
+      } else {
+        // Default transform
+        ticks.attr('transform', text.defaultTransform || 'translate(0,0)');
       }
     });
   }
@@ -68,6 +71,7 @@ function rotate() {
   component.text = function (_) {
     if (!arguments.length) return text;
     text.transform = typeof _.transform !== 'undefined' ? _.transform : text.transform;
+    text.defaultTransform = typeof _.defaultTransform !== 'undefined' ? _.defaultTransform : text.defaultTransform;
     text.x = typeof _.x !== 'undefined' ? _.x : text.x;
     text.y = typeof _.y !== 'undefined' ? _.y : text.y;
     text.dx = typeof _.dx !== 'undefined' ? _.dx : text.dx;

--- a/public/vis/components/axis/rotate.js
+++ b/public/vis/components/axis/rotate.js
@@ -17,7 +17,9 @@ function rotate() {
 
       ticks.each(function () {
         var labelLength = this.getBBox()[measure];
-        if (labelLength >= maxTickLabelLength) { isRotated = true; }
+        if (labelLength >= maxTickLabelLength) {
+          isRotated = true;
+        }
       });
 
       // Rotate and truncate

--- a/public/vis/components/visualization/heatmap.js
+++ b/public/vis/components/visualization/heatmap.js
@@ -16,8 +16,8 @@ function heatmap() {
   var rowValue = function (d) { return d.row; };
   var colValue = function (d) { return d.col; };
   var metric = function (d) { return d.value; };
-  var cAxis = { title: '', filterBy: 0 };
-  var rAxis = { title: '', filterBy: 0 };
+  var cAxis = { title: '', filterBy: 0, rotateLabels: true, rotationAngle: '-45' };
+  var rAxis = { title: '', filterBy: 0, rotateLabels: true, rotationAngle: '-30'};
   var padding = 0;
   // var sort = { row: false, col: false };
   // var reverse = { row: false, col: false };
@@ -56,14 +56,13 @@ function heatmap() {
       var colDomain = getDomain(metrics, colValue);
       var rowDomain = getDomain(metrics, rowValue);
       var colorDomain = [0, Math.max(d3.max(metrics, metric), 1)];
-
       var columnScale = d3.scale.ordinal()
         .domain(colDomain)
         .rangeBands([0, adjustedWidth], padding);
-
       var rowScale = d3.scale.ordinal()
         .domain(rowDomain)
         .rangeBands([0, adjustedHeight], padding);
+      var container;
 
       gridLayout
         .row(rowValue)
@@ -92,7 +91,10 @@ function heatmap() {
           anchor: 'middle',
           text: cAxis.title
         })
-        .rotateLabels(true);
+        .rotateLabels(cAxis.rotateLabels)
+        .rotateOptions({
+          transform: 'translate(0,0)rotate(' + cAxis.rotationAngle + ')'
+        });
 
       rowAxis
         .scale(rowScale)
@@ -109,9 +111,10 @@ function heatmap() {
           anchor: 'middle',
           text: rAxis.title
         })
-        .rotateLabels(true)
+        .rotateLabels(rAxis.rotateLabels)
         .rotateOptions({
-          transform: 'translate(-10,-8)rotate(-30)'
+          transform: 'translate(-10,-8)rotate(' + rAxis.rotationAngle + ')',
+          measure: 'height'
         });
 
       cells
@@ -136,7 +139,8 @@ function heatmap() {
       g.cssClass('container')
         .transform('translate(' + margin.left + ',' + margin.top + ')');
 
-      var container = d3.select(this)
+      // Draw Heatmap Chart
+      container = d3.select(this)
         .datum([{}])
         .call(g) // One container to rule them all!
         .select('g.container');
@@ -147,6 +151,7 @@ function heatmap() {
         .call(rowAxis)
         .call(cells);
 
+      // Legend
       container
         .datum([0].concat(colorScale.quantiles()))
         .call(legend);

--- a/public/vis/components/visualization/heatmap.js
+++ b/public/vis/components/visualization/heatmap.js
@@ -87,7 +87,8 @@ function heatmap() {
           y: margin.bottom * (2 / 3),
           anchor: 'middle',
           text: columnAxisTitle
-        });
+        })
+        .rotateLabels(true);
 
       rowAxis
         .scale(rowScale)
@@ -98,6 +99,10 @@ function heatmap() {
           y: -margin.left * (8 / 9),
           anchor: 'middle',
           text: rowAxisTitle
+        })
+        .rotateLabels(true)
+        .rotateOptions({
+          transform: 'translate(-10,-8)rotate(-30)'
         });
 
       cells


### PR DESCRIPTION
Closes #2.

Labels on axes can now be rotated. By default, the code checks to see if there is enough room to display the axis labels without them overlapping. If labels overlap, then labels will be rotated. The default rotation for the **column axis** is `45` and the default rotation for the **row axis** is `30`. 

![screen shot 2016-03-04 at 1 48 59 pm](https://cloud.githubusercontent.com/assets/3149785/13541435/02f92702-e211-11e5-9c4e-5d22f2dee15b.png)

![screen shot 2016-03-04 at 1 50 37 pm](https://cloud.githubusercontent.com/assets/3149785/13541439/0c284966-e211-11e5-8f81-91d0982d333a.png)

Please note that this doesn't prevent rotated labels from overlapping. If there are sufficiently more labels then there is reasonable space, labels will be rotated but still overlap. To solve this issue, i'd suggest [filtering](https://github.com/stormpython/heatmap/pull/12) labels. 
