### PR TITLE
Fix centering axis title bug

### DIFF
--- a/public/vis/components/axis/axis.js
+++ b/public/vis/components/axis/axis.js
@@ -69,7 +69,7 @@ function axes() {
         .attr('dx', title.dx || '')
         .attr('dy', title.dy || '.71em')
         .attr('transform', title.transform || 'translate(0,0)')
-        .style('title-anchor', title.anchor || 'end')
+        .style('text-anchor', title.anchor || 'end')
         .text(title.text || '');
     });
   }

--- a/public/vis/components/visualization/heatmap.js
+++ b/public/vis/components/visualization/heatmap.js
@@ -106,7 +106,7 @@ function heatmap() {
         })
         .title({
           transform: 'rotate(-90)',
-          x: -height / 2,
+          x: -adjustedHeight / 2,
           y: -margin.left * (8 / 9),
           anchor: 'middle',
           text: rAxis.title


### PR DESCRIPTION
Closes #3.

Axis titles were not centered properly due to a typo in the `axis` module. Now, axis titles should be centered properly along each axis.

![screen shot 2016-03-04 at 2 52 44 pm](https://cloud.githubusercontent.com/assets/3149785/13542667/2dc5492c-e219-11e5-9de3-ed518914d8a9.png)
