### PR TITLE
Adds upper boundary to legend

### DIFF
--- a/public/vis/components/legend/legend.js
+++ b/public/vis/components/legend/legend.js
@@ -28,6 +28,8 @@ function legend() {
         .call(g)
         .selectAll('g.' + cssClass)
         .each(function (data) {
+          var upperLimit = data.pop();
+
           block.cssClass('block')
             .transform(function (d, i) {
               return 'translate(0,' + (rectHeight * i) + ')';
@@ -71,7 +73,10 @@ function legend() {
                 .attr('dy', '.32em')
                 .style('text-anchor', textAnchor)
                 .text(function () {
-                  return (i === data.length - 1) ? Math.round(d) : Math.round(d) + ' - ' + Math.round(data[i + 1]);
+                  if (i === data.length - 1) {
+                    return Math.round(d) + ' - ' + Math.round(upperLimit); 
+                  }
+                  return Math.round(d) + ' - ' + Math.round(data[i + 1]);
                 });
             });
         });

--- a/public/vis/components/visualization/heatmap.js
+++ b/public/vis/components/visualization/heatmap.js
@@ -153,7 +153,7 @@ function heatmap() {
 
       // Legend
       container
-        .datum([0].concat(colorScale.quantiles()))
+        .datum([0].concat(colorScale.quantiles()).concat(colorScale.domain()[1]))
         .call(legend);
     });
   }


### PR DESCRIPTION
Closes #16.

There was a bug in the legend where the upper boundary was not added. See the issue #16 for more details.

<img width="1366" alt="screen shot 2016-03-16 at 2 35 54 am" src="https://cloud.githubusercontent.com/assets/3149785/13807748/f9af1d88-eb1f-11e5-9db0-40fd09998483.png">
