### PR TITLE
Fixes issue with scrollbar appearing after resizing the visualization

### DIFF
--- a/public/vis/index.js
+++ b/public/vis/index.js
@@ -25,7 +25,7 @@ function vis() {
       chart.options(opts);
 
       d3.select(this)
-        .attr('width', size[0])
+        .attr('width', '100%')
         .attr('height', size[1])
         .call(events)
         .call(layout)


### PR DESCRIPTION
Closes #8.

@Prazzy's suggestion regarding changing the width to relative `100%` fixes the scrollbar issue.
