### PR TITLE
Format legend numbers

### DIFF
--- a/public/heatmap.js
+++ b/public/heatmap.js
@@ -18,7 +18,8 @@ function HeatmapProvider(Private) {
         margin: { top: 20, right: 200, bottom: 100, left: 100 },
         stroke: '#ffffff',
         strokeWidth: 1,
-        padding: 0
+        padding: 0,
+        legendNumberFormat: 'number'
       },
       editor: require('plugins/heatmap/heatmap_vis_params.html')
     },

--- a/public/lib/heatmap_controller.js
+++ b/public/lib/heatmap_controller.js
@@ -78,7 +78,6 @@ module.controller('HeatmapController', function ($scope) {
         value: resp.hits.total
       }];
 
-    debugger;
     _.merge($scope.vis.params, {
       rowAxis: { title: getLabel($scope.vis.aggs, 'rows') },
       columnAxis: { title: getLabel($scope.vis.aggs, 'columns') },

--- a/public/lib/heatmap_controller.js
+++ b/public/lib/heatmap_controller.js
@@ -78,6 +78,7 @@ module.controller('HeatmapController', function ($scope) {
         value: resp.hits.total
       }];
 
+    debugger;
     _.merge($scope.vis.params, {
       rowAxis: { title: getLabel($scope.vis.aggs, 'rows') },
       columnAxis: { title: getLabel($scope.vis.aggs, 'columns') },

--- a/public/vis/components/legend/legend.js
+++ b/public/vis/components/legend/legend.js
@@ -1,4 +1,5 @@
 var d3 = require('d3');
+var numeral = require('numeral');
 var gGenerator = require('plugins/heatmap/vis/components/elements/g');
 var rectGenerator = require('plugins/heatmap/vis/components/elements/rect');
 var textGenerator = require('plugins/heatmap/vis/components/elements/text');
@@ -17,6 +18,7 @@ function legend() {
   var textAnchor = 'start';
   var textFill = '#848e96';
   var title = 'Legend';
+  var numberFormat = '0a';
   var scale = d3.scale.quantize();
   var g = gGenerator();
   var block = gGenerator();
@@ -24,6 +26,10 @@ function legend() {
   var legendTitle = textGenerator();
   var rect = rectGenerator();
   var svgText = textGenerator();
+
+  function formatNumber(num, format) {
+    return numeral(num).format(format);
+  }
 
   function generator(selection) {
     selection.each(function (datum) {
@@ -83,10 +89,12 @@ function legend() {
                 .fill(textFill)
                 .anchor(textAnchor)
                 .text(function () {
+                  var formattedNumber = formatNumber(Math.round(d), numberFormat);
+
                   if (i === data.length - 1) {
-                    return Math.round(d) + ' - ' + Math.round(upperLimit);
+                    return formattedNumber + ' - ' + formatNumber(Math.round(upperLimit), numberFormat);
                   }
-                  return Math.round(d) + ' - ' + Math.round(data[i + 1]);
+                  return formattedNumber + ' - ' + formatNumber(Math.round(data[i + 1]), numberFormat);
                 });
 
               d3.select(this)
@@ -180,6 +188,19 @@ function legend() {
   generator.title = function (v) {
     if (!arguments.length) { return title; }
     title = v;
+    return generator;
+  };
+
+  generator.numberFormat = function (v) {
+    var formats = {
+      number: '0a',
+      currency: '($0.00a)',
+      bytes: '0b',
+      percentage: '0%'
+    };
+
+    if (!arguments.length) { return numberFormat; }
+    numberFormat = formats[v] ? formats[v] : formats.number;
     return generator;
   };
 

--- a/public/vis/components/visualization/heatmap.js
+++ b/public/vis/components/visualization/heatmap.js
@@ -31,6 +31,7 @@ function heatmap() {
   var stroke = 'none';
   var strokeWidth = 0;
   var legendTitle = 'Legend';
+  var legendNumberFormat = 'number';
   var gridLayout = layout();
   var columnAxis = axis();
   var rowAxis = axis();
@@ -136,6 +137,7 @@ function heatmap() {
           return 'translate(' + x + ',' + y + ')';
         })
         .scale(colorScale)
+        .numberFormat(legendNumberFormat)
         .title(legendTitle);
 
       g.cssClass('container')
@@ -283,6 +285,12 @@ function heatmap() {
   chart.legendTitle = function (v) {
     if (!arguments.length) { return legendTitle; }
     legendTitle = v;
+    return chart;
+  };
+
+  chart.legendNumberFormat = function (v) {
+    if (!arguments.length) { return legendNumberFormat; }
+    legendNumberFormat = v;
     return chart;
   };
 


### PR DESCRIPTION
Closes #10.

Adds ability to format legend numbers.

The heatmap chart api for formating legend number is under the `legendNumberFormat` option.

The options are as follows:

```
1. "number" (default) - 12000 => 12k
2. "bytes" - 24000000 => 24MB
3. "percentage" - 10% => 10%
4. "currency" - 12.24 => $12.24
```

This uses [numeral.js](http://numeraljs.com/) formatting. Specifically:

```
1. "number" = "0a"
2. "bytes" = "0b"
3. "percentage" = "0%"
4. "currency" = "($0.00a)"
```

![screen shot 2016-04-06 at 11 46 43 am](https://cloud.githubusercontent.com/assets/3149785/14328831/50a73804-fbed-11e5-97d4-e09a3b0f703e.png)
