### PR TITLE
Closes #7. Fixes issue with median metric aggs not working

### DIFF
--- a/public/lib/heatmap_controller.js
+++ b/public/lib/heatmap_controller.js
@@ -22,7 +22,8 @@ module.controller('HeatmapController', function ($scope, Private) {
 
         table.columns.forEach(function (column, i) {
           var fieldFormatter = table.aggConfig(column).fieldFormatter();
-          var key = dataLabels[column.aggConfig.id];
+          // Median metric aggs use the parentId and not the id field
+          var key = column.aggConfig.parentId ? dataLabels[column.aggConfig.parentId] : dataLabels[column.aggConfig.id];
 
           if (key) {
             cell[key] = key !== 'value' ? fieldFormatter(row[i]) : row[i];


### PR DESCRIPTION
Closes #7.

Fixes issue with median metric aggregations not working. This was happening because the metric `aggConfig` uses the `parentId` and not the `id` on the `aggConfig` as the other aggregations do.

<img width="1352" alt="screen shot 2016-04-06 at 10 53 24 pm" src="https://cloud.githubusercontent.com/assets/3149785/14341910/713fc0d8-fc4a-11e5-9706-77f1e6b9f5c5.png">
