### PR TITLE
Support negative numbers.

### DIFF
--- a/public/vis/components/visualization/heatmap.js
+++ b/public/vis/components/visualization/heatmap.js
@@ -59,7 +59,7 @@ function heatmap() {
       var colDomain = getDomain(metrics, colValue);
       var rowDomain = getDomain(metrics, rowValue);
       var colorRange = colorbrewer[colors][numberOfColors];
-      var colorDomain = [0, Math.max(d3.max(metrics, metric), 1)];
+      var colorDomain = [Math.min(0, d3.min(metrics, metric)), Math.max(d3.max(metrics, metric), 1)];
       var columnScale = d3.scale.ordinal()
         .domain(colDomain)
         .rangeBands([0, adjustedWidth], padding);


### PR DESCRIPTION
Closes #37.

By hard coding the 0 in the color domain, the heatmap did not support negative numbers and grouped all negative numbers into the same bucket. The fix simply takes the smaller of 0 or the smallest value in the dataset.
